### PR TITLE
Update copyright year to 2026 in workflow

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           directory: './cics-java-liberty-springboot-jdbc/'
           file-extensions: '*.java'
-          base-copyright: 'Copyright IBM Corp. 2025'
+          base-copyright: 'Copyright IBM Corp. 2026'
           token: ${{ secrets.GITHUB_TOKEN }}
 
   build-maven:


### PR DESCRIPTION
Updates the copyright checker configuration to validate against 2026 instead of 2025.

## Changes
- Updated `base-copyright` in `.github/workflows/java.yaml` from 2025 to 2026

## Rationale
- Ensures copyright checker validates against current year
- Identified during repository validation against Agents.md standards

## Testing
- Workflow will run on PR and validate Java source files against 2026 copyright