### PR TITLE
Remove unused maven-publish plugin

### DIFF
--- a/cics-java-liberty-springboot-jdbc-app/build.gradle
+++ b/cics-java-liberty-springboot-jdbc-app/build.gradle
@@ -1,12 +1,11 @@
-plugins 
+plugins
 {
     id 'org.springframework.boot' version '3.5.8'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'java'
     id 'eclipse'
     id 'war'
-    id 'idea'    
-    id 'maven-publish'
+    id 'idea'
 }
 
 group = 'com.ibm.cicsdev.springboot'


### PR DESCRIPTION
- Remove maven-publish plugin from app build.gradle
- Plugin was present but had no publishing {} configuration block
- Reduces clutter and clarifies build intent (sample project, not library)
- Aligns with clean configuration practices