### PR TITLE
Modernize build configuration and fix workflow issues

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           directory: './cics-java-liberty-springboot-jdbc/'
           file-extensions: '*.java'
-          base-copyright: 'Copyright IBM Corp. 2025'
+          base-copyright: 'Copyright IBM Corp. 2026'
           token: ${{ secrets.GITHUB_TOKEN }}
 
   build-maven:
@@ -79,8 +79,10 @@ jobs:
         distribution: 'semeru'
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
+      with:
+        gradle-version: 8.14.4
     - name: Build with Gradle
-      run: ./gradlew build -Pjava_version=${{ matrix.jdk }}
+      run: gradle build -Pjava_version=${{ matrix.jdk }}
       
   build-gradlew:
     name: Build Gradle wrapper

--- a/cics-java-liberty-springboot-jdbc-app/build.gradle
+++ b/cics-java-liberty-springboot-jdbc-app/build.gradle
@@ -1,12 +1,11 @@
-plugins 
+plugins
 {
     id 'org.springframework.boot' version '3.5.8'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'java'
     id 'eclipse'
     id 'war'
-    id 'idea'    
-    id 'maven-publish'
+    id 'idea'
 }
 
 group = 'com.ibm.cicsdev.springboot'
@@ -15,9 +14,12 @@ version = '1.0.0'
 // ============================================================================
 // Java Configuration
 // ============================================================================
-java {
-    sourceCompatibility = JavaVersion.toVersion(java_version)
-    targetCompatibility = JavaVersion.toVersion(java_version)
+java
+{
+    toolchain
+    {
+        languageVersion = JavaLanguageVersion.of(java_version)
+    }
 }
 
 // ============================================================================

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,10 @@
 java_version = 17
+
+# Gradle daemon improves build performance
+org.gradle.daemon=true
+
+# Enable parallel builds for faster compilation
+org.gradle.parallel=true
+
+# Configuration cache disabled - CICS Bundle Plugin 1.0.8 not compatible
+# org.gradle.configuration-cache=true

--- a/pom.xml
+++ b/pom.xml
@@ -33,5 +33,21 @@
         <module>cics-java-liberty-springboot-jdbc-cicsbundle</module>
     </modules>
 
+    <!-- ================================================================ -->
+    <!-- Build Configuration                                              -->
+    <!-- ================================================================ -->
+    <build>
+        <plugins>
+            <!-- Maven Compiler Plugin with release parameter -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>


### PR DESCRIPTION
- Replace deprecated sourceCompatibility/targetCompatibility with Java toolchain
- Remove unused maven-publish plugin from build.gradle
- Update copyright year to 2026 in GitHub workflow
- Fix build-gradle job to use gradle command instead of wrapper
- Add gradle-version specification (8.14.4) to setup-gradle action
- Add recommended Gradle properties (daemon, parallel builds)
- Add Maven compiler plugin with release parameter to root pom.xml